### PR TITLE
chore: Compatible with service using Azure API proxies

### DIFF
--- a/GeneralAgent/skills/llm_inference.py
+++ b/GeneralAgent/skills/llm_inference.py
@@ -108,6 +108,9 @@ def _llm_inference_with_stream(client, messages, model, temperature):
         response = client.chat.completions.create(messages=messages, model=model, stream=True, temperature=temperature)
         for chunk in response:
             if len(chunk.choices) > 0:
+                # Compatible with service using Azure API proxies, such as One-API
+                if chunk.choices[0].delta is None:
+                    continue
                 token = chunk.choices[0].delta.content
                 if token is None:
                     continue


### PR DESCRIPTION
# 兼容使用Azure OpenAI代理的程序

从gptpdf过来的，十分不错的项目。但我在调试的时候一直报错
`LLM(Large Languate Model) error, Please check your key or base_url, or network`

发现我没有OpenAI官方的接口，只有Azure OpenAI的，又苦于Azure OpenAI的周边生态过于糟糕。所以使用了One API此类接口代理程序把Azure的接口对齐为OpenAI官方的，但Azure OpenAI的接口出参对于OpenAI官方的有细微的差别（苦笑

```python
# GeneralAgent/skills/llm_inference的_llm_inference_with_stream方法中
 # Compatible with service using Azure API proxies, such as One-API
                if chunk.choices[0].delta is None:
                    continue
```
只需要加上这段简短的代码，就可以兼容。
是因为Azure在流式传输的末尾会给个空的内容（很狗屎

# Compatible with Programs Using Azure OpenAI Proxies

Coming from gptpdf, it's a really nice project. But when I was debugging, I kept getting the error:
`LLM(Large Language Model) error, Please check your key or base_url, or network`

I found that I didn't have the official OpenAI interface, only Azure OpenAI, and I was frustrated with the poor ecosystem around Azure OpenAI. So I used proxy programs like One API to align Azure's interface with OpenAI's official one. However, there are slight differences in the output parameters of Azure OpenAI compared to OpenAI's official ones (sigh).

```python
# In the llm_inference_with_stream method of GeneralAgent/skills/llm_inference
# Compatible with service using Azure API proxies, such as One-API
if chunk.choices[0].delta is None:
    continue
```

Just add this short piece of code to make it compatible. This is because Azure gives an empty content at the end of the stream (very annoying).